### PR TITLE
feature/entr_tag_id_lookup

### DIFF
--- a/macros/utils/get_entr_tag_id_from_name.sql
+++ b/macros/utils/get_entr_tag_id_from_name.sql
@@ -1,0 +1,19 @@
+{#
+    TODO:
+        - add (potentially optional) validation that a single record is retrieved by query
+#}
+{% macro get_entr_tag_id_from_name(entr_tag_name) %}
+    {{ return(adapter.dispatch('get_entr_tag_id_from_name', 'entr')(entr_tag_name)) }}
+{% endmacro %}
+
+{% macro default__get_entr_tag_id_from_name(entr_tag_name) %}
+
+    {% set sql_statement -%}
+        select entr_tag_id as {{adapter.quote('ENTR_TAG_ID'|upper)}} from {{ ref('dim_entr_tag_list') }} where entr_tag_name = '{{entr_tag_name}}'
+    {%- endset %}
+
+    {%- set tag = dbt_utils.get_query_results_as_dict(sql_statement) -%}
+    
+    {% do return(tag.get('ENTR_TAG_ID')[0]) %}
+
+{% endmacro %}


### PR DESCRIPTION
Creates `get_entr_tag_id_from_name` macro to enable lookups of tag IDs based on names - rather than imposing the requirement to use either the tag name or the tag ID in model queries, we can support both patterns to facilitate both readability and efficient querying, i.e. not requiring joins each time a developer wants to reference a tag by its name. This alternative approach resolves #2.

Error handling for this macro was attempted, but I couldn't figure out a good way to do it - that will be helpful to rapidly identify breaking changes caused by renamed tags, but there may be other, better ways.

We may also consider creating a macro that returns a list of IDs for a list of tag names to reduce the number of queries happening during compilation; for now, requiring any ID lookups to be explicit and singular seems safest.
